### PR TITLE
Fix passing scrollEnable into scroll components

### DIFF
--- a/Example/react-native-head-tab-view/createCollapsibleScrollView.tsx
+++ b/Example/react-native-head-tab-view/createCollapsibleScrollView.tsx
@@ -34,7 +34,6 @@ const SceneComponent: React.FC<NormalSceneProps & HPageViewProps> = (
     {
         index,
         bounces,
-        scrollEnabled = true,
         forwardedRef,
         onScroll,
         onStartRefresh,


### PR DESCRIPTION
I got problem that props `scrollEnabled` do nothing 
And found out a problem that this props destructuring but doesn't uses
I tested logic and behavior and this fix doesn't break anythink

If you have more info about it let me knw please